### PR TITLE
Guardian UI hack - Move host url to configuration

### DIFF
--- a/guardian-ui/src/GuardianContext.tsx
+++ b/guardian-ui/src/GuardianContext.tsx
@@ -99,7 +99,7 @@ interface GuardianContextValue {
   }): Promise<void>;
   connectToHost(url: string): Promise<ConsensusState>;
   fetchConsensusState(): Promise<ConsensusState>;
-  togglePeerPolling(toggle: boolean): void;
+  toggleConsensusPolling(toggle: boolean): void;
 }
 
 export const GuardianContext = createContext<GuardianContextValue>({
@@ -110,7 +110,7 @@ export const GuardianContext = createContext<GuardianContextValue>({
   submitHostConfiguration: () => Promise.reject(),
   connectToHost: () => Promise.reject(),
   fetchConsensusState: () => Promise.reject(),
-  togglePeerPolling: () => null,
+  toggleConsensusPolling: () => null,
 });
 
 export interface GuardianProviderProps {
@@ -124,7 +124,7 @@ export const GuardianProvider: React.FC<GuardianProviderProps> = ({
 }: GuardianProviderProps) => {
   const [state, dispatch] = useReducer(reducer, initialState);
   const { password, configGenParams, myName } = state;
-  const [isPollingPeers, setIsPollingPeers] = useState(false);
+  const [isPollingConsensus, setIsPollingConsensus] = useState(false);
 
   // On mount, fetch what status the server has us at. Compare with state, and
   // redirect to the correct step if necessary.
@@ -211,7 +211,7 @@ export const GuardianProvider: React.FC<GuardianProviderProps> = ({
 
   // Poll for peer state every 2 seconds when isPollingPeers.
   useEffect(() => {
-    if (!isPollingPeers) return;
+    if (!isPollingConsensus) return;
     let timeout: ReturnType<typeof setTimeout>;
     const pollPeers = () => {
       fetchConsensusState()
@@ -224,7 +224,7 @@ export const GuardianProvider: React.FC<GuardianProviderProps> = ({
     };
     pollPeers();
     return () => clearTimeout(timeout);
-  }, [isPollingPeers]);
+  }, [isPollingConsensus]);
 
   // Single call to save all of the configuration for followers.
   const submitFollowerConfiguration: GuardianContextValue['submitFollowerConfiguration'] =
@@ -294,8 +294,8 @@ export const GuardianProvider: React.FC<GuardianProviderProps> = ({
     [myName, api, dispatch]
   );
 
-  const togglePeerPolling = useCallback((poll: boolean) => {
-    setIsPollingPeers(poll);
+  const toggleConsensusPolling = useCallback((poll: boolean) => {
+    setIsPollingConsensus(poll);
   }, []);
 
   return (
@@ -308,7 +308,7 @@ export const GuardianProvider: React.FC<GuardianProviderProps> = ({
         submitHostConfiguration,
         connectToHost,
         fetchConsensusState,
-        togglePeerPolling,
+        toggleConsensusPolling,
       }}
     >
       {children}

--- a/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/guardian-ui/src/components/ConnectGuardians.tsx
@@ -14,7 +14,7 @@ import {
   HStack,
 } from '@chakra-ui/react';
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { useGuardianContext } from '../hooks';
+import { useConsensusPolling, useGuardianContext } from '../hooks';
 import { GuardianRole, ServerStatus } from '../types';
 import { CopyInput } from './ui/CopyInput';
 import { Table, TableRow } from './ui/Table';
@@ -29,9 +29,11 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
   const {
     state: { role, peers, numPeers, configGenParams },
     api,
-    togglePeerPolling,
   } = useGuardianContext();
   const theme = useTheme();
+
+  // Poll for peers and configGenParams while on this page.
+  useConsensusPolling();
 
   const isAllConnected = numPeers && numPeers == peers.length;
   const isAllAccepted =
@@ -39,12 +41,6 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
     peers.filter((peer) => peer.status === ServerStatus.ReadyForConfigGen)
       .length >=
       numPeers - 1;
-
-  // Toggle peer polling while on this page.
-  useEffect(() => {
-    togglePeerPolling(true);
-    return () => togglePeerPolling(false);
-  }, [togglePeerPolling]);
 
   // For hosts, once all peers have connected, run DKG immediately.
   useEffect(() => {

--- a/guardian-ui/src/components/RunDKG.tsx
+++ b/guardian-ui/src/components/RunDKG.tsx
@@ -7,7 +7,7 @@ import {
   useTheme,
 } from '@chakra-ui/react';
 import React, { useEffect, useMemo, useState } from 'react';
-import { useGuardianContext } from '../hooks';
+import { useConsensusPolling, useGuardianContext } from '../hooks';
 import { ServerStatus } from '../types';
 import { formatApiErrorMessage } from '../utils/api';
 
@@ -19,17 +19,13 @@ export const RunDKG: React.FC<Props> = ({ next }) => {
   const {
     api,
     state: { peers },
-    togglePeerPolling,
   } = useGuardianContext();
   const theme = useTheme();
   const [isWaitingForOthers, setIsWaitingForOthers] = useState(false);
   const [error, setError] = useState<string>();
 
-  // Poll peers while we're on this page
-  useEffect(() => {
-    togglePeerPolling(true);
-    return () => togglePeerPolling(false);
-  }, [togglePeerPolling]);
+  // Poll for peers and configGenParams while on this page.
+  useConsensusPolling();
 
   // Keep trying to run DKG until it's finished, or we get an unexpected error.
   // "Cancel" the effect on re-run to prevent calling `runDkg` multiple times.

--- a/guardian-ui/src/components/Setup.tsx
+++ b/guardian-ui/src/components/Setup.tsx
@@ -117,10 +117,10 @@ export const Setup: React.FC = () => {
       case SetupProgress.ConnectGuardians:
         title = isHost
           ? 'Invite your Guardians'
-          : 'Join your Federation Leader';
+          : 'Confirm your Federation Information';
         subtitle = isHost
           ? 'Share the link with the other Guardians to get everyone on the same page. Once all the Guardians join, you’ll automatically move on to the next step.'
-          : 'Get your invite link from your Federation Leader, and paste it below.';
+          : 'Make sure that the information here looks right, and that the Federation Guardians are correct. Click the Approve button when you’re sure it looks good.';
         content = <ConnectGuardians next={handleNext} />;
         break;
       case SetupProgress.RunDKG:

--- a/guardian-ui/src/hooks/index.tsx
+++ b/guardian-ui/src/hooks/index.tsx
@@ -1,6 +1,20 @@
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { GuardianContext } from '../GuardianContext';
 
 export function useGuardianContext() {
   return useContext(GuardianContext);
+}
+
+/**
+ * Tells the guardian context to poll for updates. Handles turning off polling
+ * on dismount.
+ */
+export function useConsensusPolling(shouldPoll = true) {
+  const { toggleConsensusPolling } = useGuardianContext();
+
+  useEffect(() => {
+    if (!shouldPoll) return;
+    toggleConsensusPolling(true);
+    return () => toggleConsensusPolling(false);
+  }, [shouldPoll]);
 }


### PR DESCRIPTION
### What This Does

* Moves the "Join Federation link" field to the `SetConfiguration` step for followers
  * Removes this part of the flow from `ConnectGuardians`
  * Change was from Figma: https://www.figma.com/file/ioeAVbWBc3ow2RaZETatM7/Fedimint-Setup-Flow?node-id=503-24661&t=5Nv1YHbFj0BmhsJS-0
* Splits `submitConfiguration` into separate methods for host and leader
* Refactors `GuardianContext` to be more DRY
  * Reuse `fetchConsensusState` more
  * Rename peer polling to consensus polling, add reusable `useConsensusPolling()` hook for managing it
* Renders errors to user on error if `submit*Configuration` methods throw

## Screenshots

<img width="500" alt="Screenshot 2023-05-04 at 5 00 59 PM" src="https://user-images.githubusercontent.com/649992/236341615-422fe0e9-4bd2-4f7d-93c3-fa2793587c23.png">
