### PR TITLE
Guardian UI hack  peer validation

### DIFF
--- a/guardian-ui/src/GuardianApi.ts
+++ b/guardian-ui/src/GuardianApi.ts
@@ -1,5 +1,10 @@
 import { JsonRpcError, JsonRpcWebsocket } from 'jsonrpc-client-websocket';
-import { ConfigGenParams, ConsensusState, ServerStatus } from './types';
+import {
+  ConfigGenParams,
+  ConsensusState,
+  PeerHashMap,
+  ServerStatus,
+} from './types';
 
 export interface ApiInterface {
   testPassword: (password: string) => Promise<boolean>;
@@ -13,7 +18,7 @@ export interface ApiInterface {
   status: () => Promise<ServerStatus>;
   getConsensusConfigGenParams: () => Promise<ConsensusState>;
   setConfigGenParams: (params: ConfigGenParams) => Promise<void>;
-  getVerifyConfigHash: () => Promise<string>;
+  getVerifyConfigHash: () => Promise<PeerHashMap>;
   awaitConfigGenPeers: (numPeers: number) => Promise<void>;
   runDkg: () => Promise<void>;
   verifyConfigs: (configHashes: string[]) => Promise<void>;
@@ -182,7 +187,7 @@ export class GuardianApi implements ApiInterface {
     return this.rpc('set_config_gen_params', params, true /* authenticated */);
   };
 
-  getVerifyConfigHash = async (): Promise<string> => {
+  getVerifyConfigHash = async (): Promise<PeerHashMap> => {
     return this.rpc('get_verify_config_hash', null, true /* authenticated */);
   };
 
@@ -248,7 +253,7 @@ export class NoopGuardianApi implements ApiInterface {
   setConfigGenParams = async (_params: ConfigGenParams): Promise<void> => {
     return;
   };
-  getVerifyConfigHash = async (): Promise<string> => {
+  getVerifyConfigHash = async (): Promise<PeerHashMap> => {
     throw 'not implemented';
   };
   awaitConfigGenPeers = async (_numPeers: number): Promise<void> => {

--- a/guardian-ui/src/components/ConnectGuardians.tsx
+++ b/guardian-ui/src/components/ConnectGuardians.tsx
@@ -4,21 +4,19 @@ import {
   VStack,
   Button,
   FormHelperText,
-  useTheme,
   Spinner,
   TableContainer,
   Table as ChakraTable,
   Tbody,
   Tr,
   Td,
-  HStack,
+  Tag,
 } from '@chakra-ui/react';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useConsensusPolling, useGuardianContext } from '../hooks';
 import { GuardianRole, ServerStatus } from '../types';
 import { CopyInput } from './ui/CopyInput';
 import { Table, TableRow } from './ui/Table';
-import { CheckCircleIcon } from '@chakra-ui/icons';
 import { getModuleParamsFromConfig } from '../utils/api';
 
 interface Props {
@@ -30,7 +28,6 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
     state: { role, peers, numPeers, configGenParams },
     api,
   } = useGuardianContext();
-  const theme = useTheme();
 
   // Poll for peers and configGenParams while on this page.
   useConsensusPolling();
@@ -129,22 +126,17 @@ export const ConnectGuardians: React.FC<Props> = ({ next }) => {
         ? {
             key: peers[i].cert,
             name: peers[i].name,
-            status: (
-              <HStack align='center'>
-                <CheckCircleIcon boxSize={4} color={theme.colors.green[400]} />
-                <span>Connected</span>
-              </HStack>
-            ),
+            status:
+              peers[i].status === ServerStatus.ReadyForConfigGen ? (
+                <Tag colorScheme='green'>Approved</Tag>
+              ) : (
+                <Tag colorScheme='orange'>Pending</Tag>
+              ),
           }
         : {
             key: i,
             name: `Guardian ${i + 1}`,
-            status: (
-              <HStack align='center'>
-                <Spinner size='xs' />
-                <span>Waiting</span>
-              </HStack>
-            ),
+            status: <Tag colorScheme='gray'>Not joined</Tag>,
           };
       rows = [...rows, row];
     }

--- a/guardian-ui/src/components/VerifyGuardians.tsx
+++ b/guardian-ui/src/components/VerifyGuardians.tsx
@@ -2,17 +2,30 @@ import {
   Button,
   FormControl,
   FormLabel,
+  FormHelperText,
   Icon,
-  Input,
   VStack,
+  Heading,
+  Text,
+  Spinner,
+  Input,
+  Tag,
+  useTheme,
 } from '@chakra-ui/react';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormGroup } from './ui/FormGroup';
-import { FormGroupHeading } from './ui/FormGroupHeading';
 import { useGuardianContext } from '../hooks';
-import { GuardianRole } from '../types';
+import { GuardianRole, Peer } from '../types';
 import { ReactComponent as ArrowRightIcon } from '../assets/svgs/arrow-right.svg';
 import { CopyInput } from './ui/CopyInput';
+import { formatApiErrorMessage, getMyPeerId } from '../utils/api';
+import { Table } from './ui/Table';
+
+interface PeerWithHash {
+  id: string;
+  peer: Peer;
+  hash: string;
+}
 
 interface Props {
   next(): void;
@@ -20,67 +33,152 @@ interface Props {
 
 export const VerifyGuardians: React.FC<Props> = ({ next }) => {
   const {
+    api,
     state: { role },
   } = useGuardianContext();
+  const theme = useTheme();
   const isHost = role === GuardianRole.Host;
+  const [myHash, setMyHash] = useState('');
+  const [peersWithHash, setPeersWithHash] = useState<PeerWithHash[]>();
+  const [enteredHashes, setEnteredHashes] = useState<string[]>([]);
+  const [error, setError] = useState<string>();
 
-  const [verificationCode] = useState('verifyCodePlaceholder');
+  const isAllValid =
+    peersWithHash &&
+    peersWithHash.every(({ hash }, idx) => hash === enteredHashes[idx]);
 
-  const [numberOfOtherGuardians] = useState(3);
-  const [otherGuardiansVerificationCodes, setOtherGuardiansVerificationCodes] =
-    useState(
-      Array.from({ length: numberOfOtherGuardians }, () => {
-        return '';
-      })
-    );
+  useEffect(() => {
+    async function assembleHashInfo() {
+      try {
+        const [{ peers }, hashes] = await Promise.all([
+          api.getConsensusConfigGenParams(),
+          api.getVerifyConfigHash(),
+        ]);
 
-  const isValid = otherGuardiansVerificationCodes.every((x) => x !== '');
+        const myPeerId = getMyPeerId(peers);
+        if (!myPeerId) {
+          throw new Error(
+            'Unable to determine which peer you are. Please refresh and try again.'
+          );
+        }
 
-  const otherVerificationCodes = otherGuardiansVerificationCodes.map(
-    (value, index) => {
-      const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-        const newValues = [...otherGuardiansVerificationCodes];
-        newValues[index] = ev.target.value;
-        setOtherGuardiansVerificationCodes(newValues);
-      };
-      const readableIndex = isHost ? index + 1 : index;
-      const label =
-        !isHost && index === 0 ? 'Leader' : `Guardian ${readableIndex}`;
-
-      return (
-        <FormControl isRequired mb={3}>
-          <FormLabel>{label}</FormLabel>
-          <Input value={value} onChange={handleChange} />
-        </FormControl>
-      );
+        setMyHash(hashes[myPeerId]);
+        setPeersWithHash(
+          Object.entries(peers)
+            .map(([id, peer]) => ({
+              id,
+              peer,
+              hash: hashes[id],
+            }))
+            .filter((peer) => peer.id !== myPeerId)
+        );
+      } catch (err) {
+        setError(formatApiErrorMessage(err));
+      }
     }
+    assembleHashInfo();
+  }, [api]);
+
+  const handleNext = useCallback(async () => {
+    try {
+      await api.startConsensus();
+      next();
+    } catch (err) {
+      setError(formatApiErrorMessage(err));
+    }
+  }, [api]);
+
+  // Host of one immediately skips this step.
+  useEffect(() => {
+    if (isHost && isAllValid) {
+      handleNext();
+    }
+  }, [handleNext]);
+
+  const tableColumns = useMemo(
+    () => [
+      { key: 'name', heading: 'Name', width: '200px' },
+      { key: 'status', heading: 'Status', width: '160px' },
+      { key: 'hashInput', heading: 'Paste verification code' },
+    ],
+    []
   );
 
-  return (
-    <VStack gap={8} justify='start' align='start'>
-      <FormGroup>
-        <FormControl>
-          <FormLabel>Share your verification code.</FormLabel>
-          <CopyInput value={verificationCode} />
-        </FormControl>
-      </FormGroup>
-      <FormGroup>
-        <FormControl>
-          <FormGroupHeading title="Enter each guardian's verification code" />
-          {otherVerificationCodes}
-        </FormControl>
-      </FormGroup>
-      <div>
-        {!isValid && <FormLabel>All codes must be entered</FormLabel>}
-        <Button
-          isDisabled={!isValid}
-          onClick={isValid ? next : undefined}
-          leftIcon={<Icon as={ArrowRightIcon} />}
-          mt={4}
-        >
-          Next
-        </Button>
-      </div>
-    </VStack>
-  );
+  const handleChangeHash = useCallback((value: string, index: number) => {
+    setEnteredHashes((hashes) => {
+      const newHashes = [...hashes];
+      newHashes[index] = value;
+      return newHashes;
+    });
+  }, []);
+
+  const tableRows = useMemo(() => {
+    if (!peersWithHash) return [];
+    return peersWithHash.map(({ peer, hash }, idx) => {
+      const value = enteredHashes[idx] || '';
+      const isValid = Boolean(value && value === hash);
+      const isError = Boolean(value && !isValid);
+      return {
+        key: peer.cert,
+        name: (
+          <Text maxWidth={200} isTruncated>
+            {peer.name}
+          </Text>
+        ),
+        status: isValid ? <Tag colorScheme='green'>Verified</Tag> : '',
+        hashInput: (
+          <FormControl isInvalid={isError}>
+            <Input
+              variant='filled'
+              value={value}
+              placeholder='Input code here'
+              onChange={(ev) => handleChangeHash(ev.currentTarget.value, idx)}
+              readOnly={isValid}
+            />
+          </FormControl>
+        ),
+      };
+    });
+  }, [peersWithHash, enteredHashes, handleChangeHash]);
+
+  if (error) {
+    return (
+      <VStack gap={4}>
+        <Heading size='sm'>Something went wrong.</Heading>
+        <Text color={theme.colors.red[500]}>{error}</Text>
+      </VStack>
+    );
+  } else if (!peersWithHash) {
+    return <Spinner />;
+  } else {
+    return (
+      <VStack gap={8} justify='start' align='start'>
+        <FormGroup>
+          <FormControl>
+            <FormLabel>Your verification code</FormLabel>
+            <CopyInput value={myHash} />
+            <FormHelperText>
+              Share this code with other guardians
+            </FormHelperText>
+          </FormControl>
+        </FormGroup>
+        <Table
+          title='Guardian verification codes'
+          description='Enter each Guardian’s verification codes below.'
+          columns={tableColumns}
+          rows={tableRows}
+        />
+        <div>
+          <Button
+            isDisabled={!isAllValid}
+            onClick={isAllValid ? handleNext : undefined}
+            leftIcon={<Icon as={ArrowRightIcon} />}
+            mt={4}
+          >
+            Next
+          </Button>
+        </div>
+      </VStack>
+    );
+  }
 };

--- a/guardian-ui/src/components/ui/CopyInput.tsx
+++ b/guardian-ui/src/components/ui/CopyInput.tsx
@@ -37,6 +37,7 @@ export const CopyInput: React.FC<CopyInputProps> = ({ value, size = 'md' }) => {
           height={size == 'lg' ? '46px' : '42px'}
           width='100%'
           colorScheme='gray'
+          bg={theme.colors.white}
         >
           {hasCopied ? 'Copied' : 'Copy'}
         </Button>

--- a/guardian-ui/src/components/ui/Table.tsx
+++ b/guardian-ui/src/components/ui/Table.tsx
@@ -14,6 +14,7 @@ import {
 export interface TableColumn<T extends string> {
   key: T;
   heading: React.ReactNode;
+  width?: string;
 }
 
 export type TableRow<T extends string> = { key: number | string } & {
@@ -69,7 +70,12 @@ export function Table<T extends string>({
           <Thead>
             <Tr>
               {columns.map((column) => (
-                <Th key={column.key} borderBottom={border} bg='#F9FAFB'>
+                <Th
+                  key={column.key}
+                  width={column.width}
+                  borderBottom={border}
+                  bg='#F9FAFB'
+                >
                   {column.heading}
                 </Th>
               ))}
@@ -81,6 +87,7 @@ export function Table<T extends string>({
                 {columns.map((column) => (
                   <Td
                     key={column.key}
+                    width={column.width}
                     borderBottom={border}
                     borderBottomWidth={idx === rows.length - 1 ? 0 : 1}
                     height='72px'

--- a/guardian-ui/src/theme.tsx
+++ b/guardian-ui/src/theme.tsx
@@ -240,6 +240,18 @@ export const theme = extendTheme(
               },
             },
           },
+          filled: {
+            field: {
+              bg: colors.gray[50],
+              color: colors.gray[600],
+              _placeholder: {
+                color: colors.gray[400],
+              },
+              _readOnly: {
+                bg: colors.white,
+              },
+            },
+          },
         },
       },
       Select: {

--- a/guardian-ui/src/types.tsx
+++ b/guardian-ui/src/types.tsx
@@ -37,6 +37,8 @@ export interface Peer {
   status: ServerStatus;
 }
 
+export type PeerHashMap = Record<string, string>;
+
 export type LnFedimintModule = ['ln', null];
 export type MintFedimintModule = ['mint', { mint_amounts: number[] }];
 export type WalletFedimintModule = [

--- a/guardian-ui/src/utils/api.ts
+++ b/guardian-ui/src/utils/api.ts
@@ -1,5 +1,5 @@
 import { JsonRpcError } from 'jsonrpc-client-websocket';
-import { AnyFedimintModule, ConfigGenParams } from '../types';
+import { AnyFedimintModule, ConfigGenParams, Peer } from '../types';
 
 /**
  * Given a config and the name of the module, return the module
@@ -30,4 +30,16 @@ export function formatApiErrorMessage(err: unknown) {
     return (err as Error).message;
   }
   return (err as object).toString();
+}
+
+/**
+ * Given a map of peers, determine which one is you.
+ */
+export function getMyPeerId(peers: Record<string, Peer>) {
+  // TODO: Find a better way to do this than using env var?
+  const myApiUrl = new URL(process.env.REACT_APP_FM_CONFIG_API as string);
+  return Object.entries(peers).find((peer) => {
+    const apiUrl = new URL(peer[1].api_url);
+    return myApiUrl.origin === apiUrl.origin;
+  })?.[0];
 }


### PR DESCRIPTION
### What This Does

* Fully implements the `VerifyGuardians` step
  * Note that there is an issue here that if one of the peers verifies all guardians and continues from this step _before sharing their code_, all other peers will be stuck and there is no way to retrieve this code after.
* Updates types for `getVerifyConfigHash` from API
* **Minor fixes & improvements**
  * `<Table />` columns now accept a `width?: string` prop
  * Fixed `<CopyInput />` showing text from the input behind the button
  * Use the Chakra `Tag` component for statuses in the peer table
    * This doesn't yet look 1:1 with figma UI, we'll do another pass on these statuses

## Screenshots

<img width="876" alt="Screenshot 2023-05-05 at 12 24 56 PM" src="https://user-images.githubusercontent.com/649992/236525362-1d44d94b-6008-4546-ab90-dc6131f5e6f3.png">
