### PR TITLE
Guardian UI hack - GuardianContext & GuardianApi cleanup

### DIFF
--- a/guardian-ui/src/GuardianApi.ts
+++ b/guardian-ui/src/GuardianApi.ts
@@ -121,7 +121,7 @@ export class GuardianApi implements ApiInterface {
   /*** Shared RPC methods */
 
   status = async (): Promise<ServerStatus> => {
-    return this.rpc('status', null, true /* authenticated */);
+    return this.rpc('status');
   };
 
   /*** Setup RPC methods ***/
@@ -129,7 +129,7 @@ export class GuardianApi implements ApiInterface {
   setPassword = async (password: string): Promise<void> => {
     sessionStorage.setItem(SESSION_STORAGE_KEY, password);
 
-    return this.rpc('set_password', null, true /* authenticated */);
+    return this.rpc('set_password');
   };
 
   private clearPassword = () => {
@@ -145,86 +145,59 @@ export class GuardianApi implements ApiInterface {
       leader_api_url: leaderUrl,
     };
 
-    return this.rpc(
-      'set_config_gen_connections',
-      connections,
-      true /* authenticated */
-    );
+    return this.rpc('set_config_gen_connections', connections);
   };
 
-  getDefaultConfigGenParams = async (): Promise<ConfigGenParams> => {
-    let params: ConfigGenParams;
-    try {
-      params = await this.rpc(
-        'get_default_config_gen_params',
-        null,
-        false /* not-authenticated */
-      );
-    } catch (err) {
-      params = await this.rpc(
-        'get_default_config_gen_params',
-        null,
-        true /* authenticated */
-      );
-    }
-    return params;
+  getDefaultConfigGenParams = (): Promise<ConfigGenParams> => {
+    return this.rpc('get_default_config_gen_params');
   };
 
-  getConsensusConfigGenParams = async (): Promise<ConsensusState> => {
-    return this.rpc(
-      'get_consensus_config_gen_params',
-      null,
-      false /* not-authenticated */
-    );
+  getConsensusConfigGenParams = (): Promise<ConsensusState> => {
+    return this.rpc('get_consensus_config_gen_params');
   };
 
-  setConfigGenParams = async (params: ConfigGenParams): Promise<void> => {
-    return this.rpc('set_config_gen_params', params, true /* authenticated */);
+  setConfigGenParams = (params: ConfigGenParams): Promise<void> => {
+    return this.rpc('set_config_gen_params', params);
   };
 
-  getVerifyConfigHash = async (): Promise<PeerHashMap> => {
-    return this.rpc('get_verify_config_hash', null, true /* authenticated */);
+  getVerifyConfigHash = (): Promise<PeerHashMap> => {
+    return this.rpc('get_verify_config_hash');
   };
 
-  runDkg = async (): Promise<void> => {
-    return this.rpc('run_dkg', null, true /* authenticated */);
+  runDkg = (): Promise<void> => {
+    return this.rpc('run_dkg');
   };
 
-  startConsensus = async (): Promise<void> => {
-    if (this.getPassword() === null) {
-      throw new Error('password not set');
-    }
-
-    return this.rpc('start_consensus', null, true /* authenticated */);
+  startConsensus = (): Promise<void> => {
+    return this.rpc('start_consensus');
   };
 
   /*** Running RPC methods */
 
-  version = async (): Promise<Versions> => {
-    return this.rpc('version', null, true);
+  version = (): Promise<Versions> => {
+    return this.rpc('version');
   };
 
-  fetchEpochCount = async (): Promise<number> => {
-    return this.rpc('fetch_epoch_count', null, true);
+  fetchEpochCount = (): Promise<number> => {
+    return this.rpc('fetch_epoch_count');
   };
 
-  consensusStatus = async (): Promise<ConsensusStatus> => {
-    return this.rpc('consensus_status', null, true);
+  consensusStatus = (): Promise<ConsensusStatus> => {
+    return this.rpc('consensus_status');
   };
 
   /*** Internal private methods ***/
 
-  private rpc = async <P, T>(
+  private rpc = async <T>(
     method: string,
-    params: P,
-    authenticated: boolean
+    params: object | null = null
   ): Promise<T> => {
     try {
       const websocket = await this.connect();
 
       const response = await websocket.call(method, [
         {
-          auth: authenticated ? this.getPassword() : null,
+          auth: this.getPassword() || null,
           params,
         },
       ]);

--- a/guardian-ui/src/GuardianApi.ts
+++ b/guardian-ui/src/GuardianApi.ts
@@ -2,8 +2,10 @@ import { JsonRpcError, JsonRpcWebsocket } from 'jsonrpc-client-websocket';
 import {
   ConfigGenParams,
   ConsensusState,
+  ConsensusStatus,
   PeerHashMap,
   ServerStatus,
+  Versions,
 } from './types';
 
 export interface ApiInterface {
@@ -28,6 +30,11 @@ export interface ApiInterface {
   getVerifyConfigHash: () => Promise<PeerHashMap>;
   runDkg: () => Promise<void>;
   startConsensus: () => Promise<void>;
+
+  // Running RPC methods (only exist after run_consensus)
+  version: () => Promise<Versions>;
+  fetchEpochCount: () => Promise<number>;
+  consensusStatus: () => Promise<ConsensusStatus>;
 }
 
 const SESSION_STORAGE_KEY = 'guardian-ui-key';
@@ -189,6 +196,20 @@ export class GuardianApi implements ApiInterface {
     }
 
     return this.rpc('start_consensus', null, true /* authenticated */);
+  };
+
+  /*** Running RPC methods */
+
+  version = async (): Promise<Versions> => {
+    return this.rpc('version', null, true);
+  };
+
+  fetchEpochCount = async (): Promise<number> => {
+    return this.rpc('fetch_epoch_count', null, true);
+  };
+
+  consensusStatus = async (): Promise<ConsensusStatus> => {
+    return this.rpc('consensus_status', null, true);
   };
 
   /*** Internal private methods ***/

--- a/guardian-ui/src/GuardianApi.ts
+++ b/guardian-ui/src/GuardianApi.ts
@@ -176,7 +176,9 @@ export class GuardianApi implements ApiInterface {
     );
 
     return Promise.any([rpcPromise, timeoutPromise]).then(async () => {
-      // Calling `this.status()` will reboot connection to the server if it dropped.
+      // Restart a fresh socket and make sure the status is correct.
+      await this.shutdown();
+      await this.connect();
       const status = await this.status();
       if (status !== ServerStatus.ConsensusRunning) {
         throw new Error('Failed to start consensus, see logs for more info.');

--- a/guardian-ui/src/GuardianContext.tsx
+++ b/guardian-ui/src/GuardianContext.tsx
@@ -18,7 +18,6 @@ import {
 } from './types';
 import { ApiInterface, GuardianApi } from './GuardianApi';
 import { JsonRpcError } from 'jsonrpc-client-websocket';
-import { formatApiErrorMessage } from './utils/api';
 
 const LOCAL_STORAGE_KEY = 'guardian-ui-state';
 
@@ -177,8 +176,8 @@ export const GuardianProvider: React.FC<GuardianProviderProps> = ({
             payload: true,
           });
         } else {
-          // TODO: Some better display than an alert!
-          alert(formatApiErrorMessage(err));
+          // TODO: Present error to user
+          console.error(err);
         }
       })
       .finally(() => {

--- a/guardian-ui/src/GuardianContext.tsx
+++ b/guardian-ui/src/GuardianContext.tsx
@@ -16,7 +16,7 @@ import {
   ConsensusState,
   ServerStatus,
 } from './types';
-import { ApiInterface, NoopGuardianApi } from './GuardianApi';
+import { ApiInterface, GuardianApi } from './GuardianApi';
 import { JsonRpcError } from 'jsonrpc-client-websocket';
 import { formatApiErrorMessage } from './utils/api';
 
@@ -105,7 +105,7 @@ interface GuardianContextValue {
 }
 
 export const GuardianContext = createContext<GuardianContextValue>({
-  api: new NoopGuardianApi(),
+  api: new GuardianApi(),
   state: initialState,
   dispatch: () => null,
   submitFollowerConfiguration: () => Promise.reject(),

--- a/guardian-ui/src/types.tsx
+++ b/guardian-ui/src/types.tsx
@@ -22,6 +22,11 @@ export enum ServerStatus {
   ConsensusRunning = 'ConsensusRunning',
 }
 
+export enum PeerConnectionStatus {
+  Connected = 'Connected',
+  Disconnected = 'Disconnected',
+}
+
 export enum Network {
   Testnet = 'testnet',
   Mainnet = 'mainnet',
@@ -60,6 +65,29 @@ export type ConfigGenParams = {
 export interface ConsensusState {
   requested: ConfigGenParams;
   peers: Record<string, Peer>;
+}
+
+export interface Versions {
+  core: {
+    consensus: string;
+    api: string;
+  };
+  modules: Record<number, { core: string; module: string; api: string }>;
+}
+
+export interface PeerStatus {
+  last_contribution?: number;
+  last_contribution_timestamp_seconds?: number;
+  connection_status: PeerConnectionStatus;
+  flagged: boolean;
+}
+
+export interface ConsensusStatus {
+  last_contribution: number;
+  peers_online: number;
+  peers_offline: number;
+  peers_flagged: number;
+  status_by_peer: Record<string, PeerStatus>;
 }
 
 export interface SetupState {

--- a/guardian-ui/src/types.tsx
+++ b/guardian-ui/src/types.tsx
@@ -63,36 +63,40 @@ export interface ConsensusState {
 }
 
 export interface SetupState {
+  isInitializing: boolean;
   role: GuardianRole | null;
   progress: SetupProgress;
   myName: string;
   password: string;
   configGenParams: ConfigGenParams | null;
   numPeers: number;
+  needsAuth: boolean;
   peers: Peer[];
-  myVerificationCode: string;
-  peerVerificationCodes: string[];
-  federationConnectionString: string;
+  isSetupComplete: boolean;
 }
 
 export enum SETUP_ACTION_TYPE {
+  SET_IS_INITIALIZING = 'SET_IS_INITIALIZING',
   SET_INITIAL_STATE = 'SET_INITIAL_STATE',
   SET_ROLE = 'SET_ROLE',
   SET_PROGRESS = 'SET_PROGRESS',
   SET_MY_NAME = 'SET_MY_NAME',
   SET_PASSWORD = 'SET_PASSWORD',
+  SET_NEEDS_AUTH = 'SET_NEEDS_AUTH',
   SET_CONFIG_GEN_PARAMS = 'SET_CONFIG_GEN_PARAMS',
   SET_NUM_PEERS = 'SET_NUM_PEERS',
   SET_PEERS = 'SET_PEERS',
-  SET_MY_VERIFICATION_CODE = 'SET_MY_VERIFICATION_CODE',
-  SET_PEER_VERIFICATION_CODES = 'SET_PEER_VERIFICATION_CODES',
-  SET_FEDERATION_CONNECTION_STRING = 'SET_FEDERATION_CONNECTION_STRING',
+  SET_IS_SETUP_COMPLETE = 'SET_IS_SETUP_COMPLETE',
 }
 
 export type SetupAction =
   | {
       type: SETUP_ACTION_TYPE.SET_INITIAL_STATE;
       payload: null;
+    }
+  | {
+      type: SETUP_ACTION_TYPE.SET_IS_INITIALIZING;
+      payload: boolean;
     }
   | {
       type: SETUP_ACTION_TYPE.SET_ROLE;
@@ -115,6 +119,10 @@ export type SetupAction =
       payload: string;
     }
   | {
+      type: SETUP_ACTION_TYPE.SET_NEEDS_AUTH;
+      payload: boolean;
+    }
+  | {
       type: SETUP_ACTION_TYPE.SET_NUM_PEERS;
       payload: number;
     }
@@ -123,14 +131,6 @@ export type SetupAction =
       payload: Peer[];
     }
   | {
-      type: SETUP_ACTION_TYPE.SET_MY_VERIFICATION_CODE;
-      payload: string;
-    }
-  | {
-      type: SETUP_ACTION_TYPE.SET_PEER_VERIFICATION_CODES;
-      payload: string[];
-    }
-  | {
-      type: SETUP_ACTION_TYPE.SET_FEDERATION_CONNECTION_STRING;
-      payload: string;
+      type: SETUP_ACTION_TYPE.SET_IS_SETUP_COMPLETE;
+      payload: boolean;
     };


### PR DESCRIPTION
### What This Does

This is primarily a refactor and bug fix PR, but it lays the ground work for some of the final steps of setup.

* Fixed `api.startConsensus()` timing out
  * The server restarts when this is called, so we have a client-side timeout and then check if `status === ServerStatus.ConsensusRunning` after the call / after the timeout, whichever comes first.
  * `VerifyGuardians` now makes the button render in a loading state while this is being called
* Move initialization logic into `GuardianContext`
  * New state variables `isInitializing`, `needsAuth`, and `isSetupComplete`
  * Removes auth check logic from `Setup` and moves it into the context
  * Automatically sets `isSetupComplete: true` if your server status is `ConsensusRunning`
* Cleaned up unused `GuardianContext` state keys and actions
  * `myVerificationCode`, `peerVerificationCodes`, and `federationConnectionString` are all gone
* Cleaned up `GuardianApi` code
  * Make `params` param optional on `rpc`
    * Defaults to `null`
  * Removed the `authed: boolean` param from `rpc`
    * Now that the API allows it, always send auth if available instead of selectively on certain RPCs
  * Remove `NoopGuardianApi` since initializing the `GuardianApi` class no longer calls `connect` automatically
  * Removed a bunch of unnecessary `async` from functions that didn't use `await`
  * Removed some unused rpc methods
* Added new `GuardianApi` RPC methods for when the server is running
  * These aren't used _yet_ but my next PR will use them to show a final screen